### PR TITLE
Add ninja and swig to build-system requirements

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,11 +2,12 @@
 [build-system]
 requires = [
   "meson",
+  "ninja",
   "numpy",
   "pybind11",
   "scikit-build-core",
   "setuptools_scm",
-  "swig; sys_platform == 'darwin'",
+  "swig",
 ]
 build-backend = "scikit_build_core.build"
 


### PR DESCRIPTION
This makes this project possible to compile on onprem RHEL workstations where /usr/bin/ninja is old and swig not installed.