### PR TITLE
Make sqlitedict an optional transitive dependency

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,8 +60,10 @@ ExternalProject_Add(
     # https://github.com/mdolab/pyoptsparse/pull/433 is merged.
     INSTALL_COMMAND meson install --destdir ${CMAKE_BINARY_DIR}
     # patching out all the modules we did not compile from pyoptsparse/__init__.py
+    # and making sqlitedict optional
     PATCH_COMMAND
-        patch pyoptsparse/__init__.py ${CMAKE_SOURCE_DIR}/pyoptsparse.patch
+        patch pyoptsparse/__init__.py ${CMAKE_SOURCE_DIR}/pyoptsparse.patch &&
+        patch -p1 -i ${CMAKE_SOURCE_DIR}/make_sqlitedict_optional.patch
 )
 message(STATUS "Finished configuring pyoptsparse")
 

--- a/make_sqlitedict_optional.patch
+++ b/make_sqlitedict_optional.patch
@@ -1,0 +1,33 @@
+diff --git a/pyoptsparse/pyOpt_history.py b/pyoptsparse/pyOpt_history.py
+index 8f82f23..e526f75 100644
+--- a/pyoptsparse/pyOpt_history.py
++++ b/pyoptsparse/pyOpt_history.py
+@@ -5,7 +5,10 @@ import os
+ 
+ # External modules
+ import numpy as np
+-from sqlitedict import SqliteDict
++try:
++    from sqlitedict import SqliteDict
++except ImportError:
++    pass
+ 
+ # Local modules
+ from .pyOpt_error import pyOptSparseWarning
+diff --git a/pyoptsparse/pyOpt_optimization.py b/pyoptsparse/pyOpt_optimization.py
+index 38d9024..f58ef10 100644
+--- a/pyoptsparse/pyOpt_optimization.py
++++ b/pyoptsparse/pyOpt_optimization.py
+@@ -9,7 +9,10 @@ import warnings
+ import numpy as np
+ from numpy import ndarray
+ from scipy.sparse import coo_matrix
+-from sqlitedict import SqliteDict
++try:
++    from sqlitedict import SqliteDict
++except ImportError:
++    pass
+ 
+ # Local modules
+ from .pyOpt_MPI import MPI
+


### PR DESCRIPTION
All tests in everest-optimizers will pass with pyOptSparse including this patch.

Resolves #112 